### PR TITLE
Pin OneSDK version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@superfaceai/one-sdk": "^3.0.0-alpha.6"
+        "@superfaceai/one-sdk": "3.0.0-alpha.6"
       },
       "devDependencies": {
         "wrangler": "^2.20.0"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Superface Team <hello@superface.ai>",
   "private": true,
   "dependencies": {
-    "@superfaceai/one-sdk": "^3.0.0-alpha.6"
+    "@superfaceai/one-sdk": "3.0.0-alpha.6"
   },
   "devDependencies": {
     "wrangler": "^2.20.0"


### PR DESCRIPTION
As the version specifier is with caret `^`, releasing new alpha with breaking changes would break this demo. 

OneSDK should be updated explicitly.